### PR TITLE
Ignore RVM artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
 .idea
+.ruby-gemset
+.ruby-version


### PR DESCRIPTION
Ignore RVM artifacts. Ensure that these files are not accidentally checked in during a merge
