### PR TITLE
Further contrain rails gem requirement

### DIFF
--- a/multipluck.gemspec
+++ b/multipluck.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 3.2.0"
+  s.add_dependency "rails", ">= 3.2.0", "< 4.0"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Ensure that the bundled version of rails is >= 3.2 and < 4.0
