### PR TITLE
Run Travis-CI script command in a subshell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ rvm:
   - 1.9.2
   - 1.9.3
 script:
-  - cd test/dummy && RAILS_ENV=test bundle exec rake --trace db:migrate test && cd ../..
+  - (cd test/dummy && RAILS_ENV=test bundle exec rake --trace db:migrate test)
 


### PR DESCRIPTION
Rather than changing directories twice, into the dummy-app and back to
the project root, run the script command in a subshell so the current
working directory is preserved
